### PR TITLE
fix(devloop): auto-commit tasks before prompting user in continue workflow

### DIFF
--- a/plugins/devloop/.claude-plugin/plugin.json
+++ b/plugins/devloop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devloop",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Token-conscious feature development workflow with enhanced engineer agent (6 new skills, mode-specific workflows, complexity-aware selection), mandatory checkpoint enforcement, loop completion detection, context management, fresh start mechanism, spike-to-plan application, worklog sync automation, consolidated super-agents (18→9), XML-structured prompts, unified language patterns, strategic model selection (opus/sonnet/haiku), and comprehensive documentation (agents.md, testing.md)",
   "author": {
     "name": "Zate",


### PR DESCRIPTION
BREAKING CHANGE: The /devloop:continue workflow now automatically commits
completed tasks BEFORE asking the user what to do next. This ensures no task
is considered complete until changes are committed to git.

Changes:
- Added Step 5a.3: Commit Changes (for successful completion)
- Commits happen automatically after task completion
- Removed "Commit this work" option from checkpoint (now automatic)
- Updated partial completion handlers to commit when marking done
- Incremented version to 2.2.1

Fixes the issue where users were prompted for next action before changes
were committed, creating confusion about task completion status.