### PR TITLE
fix(blog-writer): author field must be object in manifest

### DIFF
--- a/plugins/blog-writer/.claude-plugin/plugin.json
+++ b/plugins/blog-writer/.claude-plugin/plugin.json
@@ -2,9 +2,12 @@
   "name": "blog-writer",
   "version": "1.0.0",
   "description": "Conversational blog post creator that interviews you, writes in your voice, and strips AI tells",
-  "author": "Zate",
-  "homepage": "https://github.com/zate/cc-plugins",
-  "repository": "https://github.com/zate/cc-plugins",
+  "author": {
+    "name": "Zate",
+    "email": "zate75+claude-code-plugins@gmail.com"
+  },
+  "homepage": "https://github.com/Zate/cc-plugins",
+  "repository": "https://github.com/Zate/cc-plugins",
   "license": "MIT",
   "keywords": ["claude-code", "plugin", "blog", "writing", "content"]
 }


### PR DESCRIPTION
## Summary
- Fix invalid plugin manifest: `author` field must be an object `{name, email}`, not a plain string
- This was causing `/doctor` to report an invalid manifest

## Test plan
- [ ] `/plugin marketplace update cc-plugins` shows blog-writer
- [ ] `/plugin install blog-writer` succeeds
- [ ] `/doctor` reports no errors for blog-writer